### PR TITLE
Optimize TryLibrary.lua

### DIFF
--- a/TryLibrary.lua
+++ b/TryLibrary.lua
@@ -24,7 +24,7 @@ local function Try(Function, ...)
 	self.Stack = debug.traceback();
 	self.LastArguments = { ... };
 	self.Hops = (not Success) and { Function } or nil;
-	self.Id = tostring(self):gsub('table', 'attempt');
+	self.Id = tostring(self);
 
 	return setmetatable(self, Attempt);
 
@@ -37,7 +37,7 @@ Attempt.__index = Attempt;
 
 -- Indicate type when converted to string (to aid in debugging)
 function Attempt:__tostring()
-	return self.Id
+	return self.Id:gsub('table', 'attempt');
 end;
 
 -- Attempt Methods

--- a/TryLibrary.lua
+++ b/TryLibrary.lua
@@ -45,7 +45,7 @@ function Attempt:Then(Callback)
 
 	-- Skip processing if attempt failed
 	if not self.Success then
-		table.insert(self.Hops, Callback);
+		self.Hops[#self.Hops + 1] = Callback;
 		return self;
 	end;
 

--- a/TryLibrary.lua
+++ b/TryLibrary.lua
@@ -1,189 +1,172 @@
-function Try(Function, ...)
+-- @readme https://github.com/F3XTeam/RBX-Try-Library/blob/master/README.md
 
+local Attempt = {
+	_IsAttempt = true;	
+	RetryCount = 0;
+	Start = true;
+}
+Attempt.__index = Attempt
+
+-- Indicate type when converted to string (to aid in debugging)
+function Attempt:__tostring()
+	return self.Id
+end
+
+local function Try(Function, ...)
 	-- Capture function execution response
-	local Data = { pcall(Function, ...) };
+	local Arguments = { pcall(Function, ...) };
 
 	-- Determine whether execution succeeded or failed
-	local Success = Data[1];
-	
-	-- Gather arguments to return from data
-	local Arguments = { unpack(Data, 2) };
+	local Success = table.remove(Arguments, 1);
 
-	-- Return attempt for chaining
-	return setmetatable({
-		_IsAttempt = true,
-		Then = Then,
-		Catch = Catch,
-		Retry = Retry,
-		Success = Success,
+	-- Create new Attempt for chaining
+	local self = {
+		-- Gather arguments to return from data
 		Arguments = Arguments,
+		Success = Success,		
 		Stack = debug.traceback(),
 		LastArguments = { ... },
-		Hops = (not Success) and { Function } or nil,
-		RetryCount = 0,
-		Start = true
-
-	-- Indicate type when converted to string (to aid in debugging)
-	}, { __tostring = function () return 'Attempt' end })
-
+		Hops = (not Success) and { Function } or nil
+	}
+	self.Id = tostring(self):gsub('table', 'attempt');
+	return setmetatable(self, Attempt);
 end;
 
-function Then(Attempt, Callback)
+function Attempt:Then(Callback)
 
 	-- Update attempt state
-	Attempt.Start = false;
+	self.Start = false;
 
 	-- Enter new attempt contexts if received
-	local FirstArgument = Attempt.Arguments[1];
-	if Attempt.Success and type(FirstArgument) == 'table' and FirstArgument._IsAttempt then
-		Attempt = FirstArgument;
+	local FirstArgument = self.Arguments[1];
+	if self.Success and type(FirstArgument) == 'table' and FirstArgument._IsAttempt then
+		self = FirstArgument;
 	end;
 
 	-- Skip processing if attempt failed
-	if not Attempt.Success then
-		table.insert(Attempt.Hops, Callback);
-		return Attempt;
+	if not self.Success then
+		table.insert(self.Hops, Callback);
+		return self;
 	end;
 
 	-- Capture callback execution response
-	local Data = { pcall(Callback, unpack(Attempt.Arguments)) };
-	local Success = Data[1];
-	local Arguments = { unpack(Data, 2) };
+	local Arguments = { pcall(Callback, unpack(self.Arguments)) };
+	local Success = table.remove(Arguments, 1);
 
 	-- Replace attempt state
-	Attempt.Success = Success;
-	Attempt.LastArguments = Attempt.Arguments;
-	Attempt.Arguments = Arguments;
-	Attempt.Stack = debug.traceback();
+	self.Success = Success;
+	self.LastArguments = self.Arguments;
+	self.Arguments = Arguments;
+	self.Stack = debug.traceback();
 
 	-- Track hops on failure
 	if not Success then
-		Attempt.Hops = { Callback };
+		self.Hops = { Callback };
 	end
 
 	-- Return attempt for chaining
-	return Attempt;
-
+	return self;
 end;
 
-function Catch(Attempt, ...)
+function Attempt:Catch(...)
 
 	-- Capture all arguments
 	local Arguments = { ... };
 
-	-- Get target errors and the callback
-	local TargetErrors = { unpack(Arguments, 1, #Arguments - 1) };
-	local Callback = unpack(Arguments, #Arguments);
+	-- Get error count so callback = ErrorCount + 1
+	local ErrorCount = #Arguments - 1;
 
 	-- Enter new attempt contexts if received
-	local FirstArgument = Attempt.Arguments[1];
+	local FirstArgument = self.Arguments[1];
 	if type(FirstArgument) == 'table' and FirstArgument._IsAttempt then
-		Attempt = FirstArgument;
+		self = FirstArgument;
 	end;
 
 	-- Proceed upon unhandled failure
-	if not Attempt.Success and not Attempt.Handled then
+	if not self.Success and not self.Handled then
 
 		-- Track hops
-		table.insert(Attempt.Hops, Arguments);
+		self.Hops[#self.Hops + 1] = Arguments;
 
 		-- Get error from failed attempt
-		local Error = Attempt.Arguments[1];
-
-		-- Filter errors if target errors were specified
-		if (#TargetErrors > 0) then
-			for _, TargetError in pairs(TargetErrors) do
-				if type(Error) == 'string' and Error:match(TargetError) then
-					Attempt.Handled = true;
-					return Try(Callback, Error, Attempt.Stack, Attempt);
-				end;
-			end;
+		local Error = self.Arguments[1];
 
 		-- Pass any error if no target errors were specified
-		elseif #TargetErrors == 0 then
-			Attempt.Handled = true;
-			return Try(Callback, Error, Attempt.Stack, Attempt);
+		if ErrorCount == 0 then
+			self.Handled = true;
+			return Try(Arguments[ErrorCount + 1], Error, self.Stack, self);
+
+		-- Filter errors if target errors were specified
+		elseif type(Error) == 'string' then
+			for a = 1, ErrorCount do
+				if Error:match(Arguments[a]) then
+					self.Handled = true;
+					return Try(Arguments[ErrorCount + 1], Error, self.Stack, self);
+				end;
+			end;
 		end;
 
 	end;
 
 	-- Return attempt for chaining
-	return Attempt;
-
+	return self;
 end;
 
-function Retry(Attempt)
+function Attempt:Retry()
 
 	-- Ensure attempt failed
-	if Attempt.Success then
-		return;
-	end;
+	if not self.Success then
+		-- Get hops and arguments
+		local Hops = self.Hops;
+		local Arguments = self.LastArguments;
+		local RetryCount = self.RetryCount + 1;
 
-	-- Get hops and arguments
-	local Hops = Attempt.Hops;
-	local Arguments = Attempt.LastArguments;
+		-- Reset attempt state		
+		self.Arguments = Arguments;
+		self.RetryCount = RetryCount;
+		self.Success, self.Hops, self.Handled = true;
 
-	-- Reset attempt state
-	Attempt.Hops = nil;
-	Attempt.Success = true;
-	Attempt.Arguments = Arguments;
-	Attempt.Handled = nil;
-	Attempt.RetryCount = Attempt.RetryCount and (Attempt.RetryCount + 1) or 1;
+		-- Restart attempts that failed from the start
+		if self.Start then
+			self = Try(Hops[1], Arguments);
 
-	-- Restart attempts that failed from the start
-	if Attempt.Start then
-		local NewAttempt = Try(Hops[1], Arguments);
-
-		-- Reset retry counter if reattempt succeeds
-		if NewAttempt.Success then
-			NewAttempt.RetryCount = 0;
+		-- Continue attempts that failed after the start
 		else
-			NewAttempt.RetryCount = Attempt.RetryCount;
-		end;
-
-		-- Apply each hop
-		for HopIndex, Hop in ipairs(Hops) do
-			if HopIndex > 1 then
-
-				-- Apply `then` hops
-				if type(Hop) == 'function' then
-					NewAttempt:Then(Hop);
-					
-				-- Apply `catch` hops
-				elseif type(Hop) == 'table' then
-					NewAttempt:Catch(unpack(Hop));
-				end;
-
-			end;
-		end;
-		
-		-- Return the new attempt
-		return NewAttempt;
-	
-	-- Continue attempts that failed after the start
-	else
-		for HopIndex, Hop in ipairs(Hops) do
-
-			-- Apply `then` hoops
-			if type(Hop) == 'function' then
-				Attempt:Then(Hop);
+			local Hop = Hops[1];
+			local HopMetatable = getmetatable(Hop);
 
 			-- Apply `catch` hops
-			elseif type(Hop) == 'table' then
-				Attempt:Catch(unpack(Hop));
-			end;
+			if type(Hop) == 'table' and (not HopMetatable or not HopMetatable.__call) then
+				self:Catch(unpack(Hop));
 			
-			-- Reset retry counter if reattempt succeeds
-			if HopIndex == 1 and Attempt.Success then
-				Attempt.RetryCount = 0;
+			-- Apply `then` hops
+			else
+				self:Then(Hop);
+			end;
+		end
+
+		-- Reset retry counter if reattempt succeeds
+		self.RetryCount = self.Success and 0 or RetryCount;
+
+		-- Apply each hop
+		for HopIndex = 2, #Hops do
+			local Hop = Hops[HopIndex];
+			local HopMetatable = getmetatable(Hop);
+
+			-- Apply `catch` hops
+			if type(Hop) == 'table' and (not HopMetatable or not HopMetatable.__call) then
+				self:Catch(unpack(Hop));
+			
+			-- Apply `then` hops
+			else
+				self:Then(Hop);
 			end;
 
 		end;
 
 		-- Return the attempt
-		return Attempt;
+		return self;
 	end;
-
 end;
 
 return Try;


### PR DESCRIPTION
- Use __index metamethod instead of replicating pointers for each table
- Remove unnecessary `Data` and `TargetError` tables and instead only use one table and `table.remove`
- Removed unnecessary tables
- Removed unnecessary `unpack` calls
- Replaced `Argument` parameter with `self` (more OOP style)
- Allow for callable tables to be passed as the parameters `Function` and `Callback`
- Reduce unnecessary/duplicate function calls
- Make `Retry` have uniform logic after resetting attempt state
- Make `__tostring` metamethod include an id
- Switch `ipairs` and `pairs` out for simple for loops (which are much faster)
- Add description
- Add `readme` link to top of file
- Remove _IsAttempt (which is writable to any table) and instead identifies Attempts with `getmetatable(self) == Attempt`
- Added pcall Packaging internal helper function which is faster than `table.remove` and doesn't require the creation of more than a single table

And, it's shorter :D

Note: Didn't change actual functionality