### PR TITLE
(Develop) Remove redundant calls, remove execute method

### DIFF
--- a/TryLibrary.lua
+++ b/TryLibrary.lua
@@ -1,19 +1,6 @@
 -- A library for controlling the flow of error-prone, interdependent functions
 -- @readme https://github.com/F3XTeam/RBX-Try-Library/blob/master/README.md
 
-local function IsAttempt(Object)
-	--- Identifies whether an Object is of the Attempt class
-	-- @param table Object
-	-- @returns boolean whether _IsAttempt == true in a table's metatable
-
-	-- Get object metatable
-	local ObjectMetatable = getmetatable(Object);
-
-	-- Return whether metatable indicates object is an attempt
-	return ObjectMetatable and ObjectMetatable._IsAttempt or false;
-
-end;
-
 local function PackageProtectedCall(self, Success, ...)
 	--- Packages (self, pcall()) updates Attempt self
 	-- @returns Attempt self
@@ -62,74 +49,78 @@ end;
 function Attempt:Then(Callback)
 	-- Passes attempt results to callback, and returns attempt for chaining
 
-	-- Enter new attempt context if received
-	local FirstArgument = self.Results[1];
-	if self.Success and IsAttempt(FirstArgument) then
-		self = FirstArgument;
-	end;
+	if self.Success then
+
+		-- Enter new attempt context if received
+		if getmetatable(self.Results[1]) == Attempt then
+			self = self.Results[1];
+		end
+
+		self.Function = Function;
+		self.Arguments = self.Results;
+
+		-- Execute callback with results of last attempt
+		return PackageProtectedCall(self, pcall(Function, unpack(self.Results)));
 
 	-- Skip callback if attempt failed
-	if not self.Success then
+	else
 		self.Skips[#self.Skips + 1] = Callback;
 		return self;
 	end;
-
-	self.Function = Function;
-	self.Arguments = self.Results;
-
-	-- Execute callback with results of last attempt
-	return PackageProtectedCall(self, pcall(Function, unpack(self.Results)));
-
+	
 end;
 
 function Attempt:Catch(...)
 	-- Passes errors in failed attempt to given callback, returns attempt for chaining
 
-	-- Enter new attempt context if received
-	local FirstArgument = self.Results[1];
-	if self.Success and IsAttempt(FirstArgument) then
-		self = FirstArgument;
-	end;
+	local FirstResult = self.Results[1];
 
 	-- Skip catching if attempt succeeded
-	if self.Success or self.Handled then
-		return self;
-	end;
+	if self.Success then
 
-	-- Get arguments
-	local Arguments = { ... };
+		-- Enter new attempt context if received
+		if getmetatable(FirstResult) == Attempt then
+			return FirstResult;
+		end
 
-	-- Get predicate count and callback
-	local PredicateCount = #Arguments - 1;
-	local Callback = Arguments[PredicateCount + 1];
+	-- Attempt failed, catch
+	elseif not self.Handled then
 
-	-- Track catching operation for future retry attempts
-	self.Skips[#self.Skips + 1] = Arguments;
+		-- Get arguments
+		local Arguments = { ... };
 
-	-- Get attempt error
-	local Error = self.Results[1];
-	local HandleError = false;
+		-- Get predicate count and callback
+		local PredicateCount = #Arguments - 1;
+		local Callback = Arguments[PredicateCount + 1];
 
-	-- Handle any error if no predicates specified
-	if PredicateCount == 0 then
-		HandleError = true;
+		-- Track catching operation for future retry attempts
+		self.Skips[#self.Skips + 1] = Arguments;
 
-	-- Handle matching error if predicates specified
-	elseif type(Error) == 'string' then
-		for PredicateId = 1, PredicateCount do
-			if Error:match(Arguments[PredicateId]) then
-				HandleError = true;
-				break;
+		-- Get attempt error
+		local HandleError = false;
+
+		-- Handle any error if no predicates specified
+		if PredicateCount == 0 then
+			HandleError = true;
+
+		-- Handle matching error if predicates specified
+		elseif type(FirstResult) == 'string' then
+			for PredicateId = 1, PredicateCount do
+				if FirstResult:match(Arguments[PredicateId]) then
+					HandleError = true;
+					break;
+				end;
 			end;
 		end;
-	end;
 
-	-- Attempt passing error to callback, and return attempt on success
-	if HandleError then
-		return Try(Callback, Error, self.Stack, self):Then(function ()
-			self.Handled = true;
-			return self;
-		end);
+		-- Attempt passing error to callback, and return attempt on success
+		if HandleError then
+			return Try(Callback, FirstResult, self.Stack, self):Then(function()
+				self.Handled = true;
+				return self;
+			end);
+		end;
+
 	end;
 
 	-- Return attempt for chaining
@@ -141,46 +132,45 @@ function Attempt:Retry()
 	-- Retries attempt from first failure, applies skipped operations, and returns resulting attempt
 
 	-- Skip retrying if attempt succeeded
-	if self.Success then
-		return;
-	end;
+	if not self.Success then
 
-	-- Get skips after attempt failure
-	local Skips = self.Skips;
+		-- Get skips after attempt failure
+		local Skips = self.Skips;
 
-	-- Reset attempt for reexecution
-	self.Handled = nil;
-	self.Skips = nil;
-	self.Stack = nil;
+		-- Reset attempt for reexecution
+		self.Handled = nil;
+		self.Skips = nil;
+		self.Stack = nil;
 
-	-- Increment retry counter
-	self.RetryCount = self.RetryCount + 1;
+		-- Increment retry counter
+		self.RetryCount = self.RetryCount + 1;
 
-	-- Retry attempt
-	PackageProtectedCall(self, pcall(self.Function, unpack(self.Arguments)));
+		-- Retry attempt
+		PackageProtectedCall(self, pcall(self.Function, unpack(self.Arguments)));
 
-	-- Reset retry counter if retry succeded
-	if self.Success then
-		self.RetryCount = nil;
-	end;
-
-	-- Apply skipped operations
-	for SkipIndex = 1, #Skips do
-		local Skip = Skips[SkipIndex];
-		local SkipMetatable = getmetatable(Skip);
-
-		-- Apply callables as `then` operations
-		if type(Skip) == 'function' or (SkipMetatable and SkipMetatable.__call) then
-			self = self:Then(Skip);
-
-		-- Apply non-callables as `catch` operations
-		else
-			self = self:Catch(unpack(Skip));
+		-- Reset retry counter if retry succeded
+		if self.Success then
+			self.RetryCount = nil;
 		end;
-	end;
 
-	-- Return attempt for chaining
-	return self;
+		-- Apply skipped operations
+		for SkipIndex = 1, #Skips do
+			local Skip = Skips[SkipIndex];
+			local SkipMetatable = getmetatable(Skip);
+
+			-- Apply callables as `then` operations
+			if type(Skip) == 'function' or (SkipMetatable and SkipMetatable.__call) then
+				self = self:Then(Skip);
+
+			-- Apply non-callables as `catch` operations
+			else
+				self = self:Catch(unpack(Skip));
+			end;
+		end;
+
+		-- Return attempt for chaining
+		return self;
+	end;
 
 end;
 

--- a/TryLibrary.lua
+++ b/TryLibrary.lua
@@ -15,7 +15,8 @@ local function IsAttempt(Object)
 end;
 
 local function PackageProtectedCall(self, Success, ...)
-	-- Executes function with given arguments, saves results in attempt
+	--- Packages (self, pcall()) updates Attempt self
+	-- @returns Attempt self
 
 	-- Update attempt state with execution information
 	self.Success = Success;


### PR DESCRIPTION
- Moved execute into PackageProtectedCall (it isn't a methed meant to be externally used)
- Cut down further redundant function calls
- Removed redundant `Function` and `Arguments` setting from `Retry`
- Update documentation a little